### PR TITLE
`tell*` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "aria2-rs-yet"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "futures-util",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aria2-rs-yet"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["hxzhao527 <haoxiangzhao@outlook.com>"]
 description = "Yet Another Aria2 JSON-RPC Client."

--- a/README.md
+++ b/README.md
@@ -6,3 +6,51 @@ Yet Another Aria2 JSON-RPC Client. Inspired by [aria2-rs](https://github.com/ihc
 ## Features
 - [x] Simple direct call via websocket.
 - [x] Notification from websocket.
+
+## example
+
+download a file and print taks status.
+
+```rust
+use aria2_rs_yet::{Client, ConnectionMeta, Result};
+use aria2_rs_yet::call::{AddUri, TellStatus, TellStatusField};
+use aria2_rs_yet::options::Aria2Options;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).init();
+    
+    let (client, _) = Client::connect(
+        ConnectionMeta::new(
+            "ws://localhost:6800/jsonrpc",
+            Some("<rpc-secret>"),
+        )
+    ).await?;
+
+    let gid = client.call(
+        AddUri::new(
+            vec!["https://github.com/hxzhao527/aria2-rs-yet/archive/refs/heads/master.zip"],
+            Some(Aria2Options{
+                dir: Some("/tmp".to_string()),
+                out: Some("aria2-rs-yet.zip".to_string()),
+                ..Default::default()
+            }),
+            None,
+        )
+    ).await?;
+    println!("{:?}", gid);
+
+    let status = client.call(
+        TellStatus::new(gid).fields(Some([TellStatusField::Status, TellStatusField::Gid]))
+    ).await?;
+    println!("{:?}", status);
+
+    // drop(client); // uncomment this line to see the client disconnecting
+    println!("waiting for ctrl-c");
+    tokio::signal::ctrl_c().await.unwrap();
+    Ok(())
+}
+```
+
+## License
+MIT License

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,5 +1,5 @@
 use aria2_rs_yet::{Client, ConnectionMeta, Result};
-use aria2_rs_yet::call::{SystemListMethods, GetVersion, AddUri, TellStatus};
+use aria2_rs_yet::call::{SystemListMethods, GetVersion, AddUri, TellStatus, TellStatusField, TellStopped};
 use aria2_rs_yet::options::Aria2Options;
 
 #[tokio::main]
@@ -33,9 +33,14 @@ async fn main() -> Result<()> {
     println!("{:?}", gid);
 
     let status = client.call(
-        TellStatus::new(gid)
+        TellStatus::new(gid).fields(Some([TellStatusField::Status, TellStatusField::Gid]))
     ).await?;
     println!("{:?}", status);
+
+    let stoped = client.call(
+        TellStopped::new(0, 1)
+    ).await?;
+    println!("{:?}", stoped);
 
     // drop(client); // uncomment this line to see the client disconnecting
     println!("waiting for ctrl-c");

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -140,6 +140,8 @@ impl ClientInner {
             Some(params) => Some(serde_json::to_value(params).map_err(Error::Encode)?),
             None => None,
         };
+        
+        tracing::debug!("call method: {}, params: {:?}", method, params);
 
         let request = RPCRequest {
             params,


### PR DESCRIPTION
1. 实现`tell*`
3. 调整keys的数据结构, 用hashset代替vec保证不重复
4. 补充`tellStatus`相关的`get*`方法(不含bt部分)